### PR TITLE
chore: update Go workflow to use go.mod for versioning and disable ca…

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
+          cache: false
 
       - name: Build
         run: go build -v ./...
@@ -70,9 +71,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.18
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4


### PR DESCRIPTION
…ching

- Changed the Go version setup to read from go.mod instead of a matrix variable.
- Disabled caching for the Go setup to ensure a clean build environment.