### PR TITLE
fix(vuln): update Go 1.26.1 → 1.26.2 to fix stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/cfssl
 
-go 1.26.1
+go 1.26.2
 
 require (
 	bitbucket.org/liamstask/goose v0.0.0-20150115234039-8488cc47d90c


### PR DESCRIPTION
## Summary

- Update `go 1.26.1` → `go 1.26.2` in `go.mod`

## Fixed CVEs

| Severity | CVSS | CVE | Package |
|----------|------|-----|---------|
| HIGH | 8.8 | CVE-2026-33810 | stdlib |
| HIGH | 7.8 | CVE-2026-32282 | stdlib |
| HIGH | 7.5 | CVE-2026-32280 | stdlib |
| MEDIUM | 5.9 | CVE-2026-32281 | stdlib |
| MEDIUM | 5.4 | CVE-2026-32289 | stdlib |
| MEDIUM | 4.3 | CVE-2026-32288 | stdlib |
| UNKNOWN | - | CVE-2026-32283 | stdlib |

## Test plan

- [ ] CI builds pass
- [ ] New release tagged and binaries confirm `go version` = 1.26.2