### PR TITLE
fix(vuln): CVE remediation 2026-05-09

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/cfssl
 
-go 1.26.2
+go 1.26.3
 
 require (
 	bitbucket.org/liamstask/goose v0.0.0-20150115234039-8488cc47d90c


### PR DESCRIPTION
Automated CVE fix: updated Go 1.26.2 → 1.26.3, fixing stdlib vulnerabilities (html/template XSS, net/http HTTP/2, net NUL byte panic, net/mail quadratic).