### PR TITLE
fix(vuln): bump go 1.26.4 to patch stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/cfssl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	bitbucket.org/liamstask/goose v0.0.0-20150115234039-8488cc47d90c


### PR DESCRIPTION
## Summary
- Bump `go` directive 1.26.3 → 1.26.4

## CVEs (stdlib)
- CVE-2026-42504 (7.5), CVE-2026-27145 (6.5), CVE-2026-42507 (5.3)

Needed by gitlab-chart alauda-18.5.4 vuln scan (cfssl binary embeds stdlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)